### PR TITLE
A small test suite to test JIRA-REST-Class against public JIRA service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: "perl"
+
+perl:
+  - "5.20"
+
+install:
+    - "(dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest)"
+    - "(dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose)"
+    - cpanm --notest -q Sparrow
+    - sparrow plg install jira-rest-class-smoke 
+
+script: "export PERL5LIB=$PWD/lib && sparrow plg run jira-rest-class-smoke --param jira_user=$jira_user --param jira_password=$jira_password"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ perl:
 
 install:
     - "(dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest)"
-    - "(dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose)"
+    - "(dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --quiet --notest -f)"
     - cpanm --notest -q Sparrow
     - sparrow plg install jira-rest-class-smoke 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ perl:
   - "5.20"
 
 install:
+    - cpanm --notest -q Pod::Elemental::Transformer::List
     - "(dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest)"
-    - "(dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --quiet --notest -f)"
+    - "(dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --quiet --notest )"
     - cpanm --notest -q Sparrow
     - sparrow plg install jira-rest-class-smoke 
 


### PR DESCRIPTION
Hi Packy!

Here is small [test suite](https://github.com/melezhik/jira-rest-class-smoke) to check if  JIRA-REST-Class works correctly with public jira server - https://issues.jenkins-ci.org . Due to the issue mentioned #2 it needs to be configured. An [example travis job](https://travis-ci.org/melezhik/JIRA-REST-Class/builds/181957618) has 2 hidden environment variables - `jira_user` and `jira_password` , so you will need to define ones after merge on your side.

Currently a suite case is very simple. Get logging into https://issues.jenkins-ci.org API and fetch JENKINS project and then print it name, the STDOUT should be 'JENKINS' which is tested.

A more tests could be added upon your interest ... 

Regards

Alexey
