### PR TITLE
Prevent croaking when JIRA uses a %F-type date

### DIFF
--- a/lib/JIRA/REST/Class/Factory.pm
+++ b/lib/JIRA/REST/Class/Factory.pm
@@ -63,19 +63,22 @@ sub make_object {
 
 Make it easy to get L<DateTime|DateTime> objects from the factory. Parses
 JIRA date strings, which are in a format that can be parsed by the
-L<DateTime::Format::Strptime|DateTime::Format::Strptime> pattern
-C<%FT%T.%N%z>
+L<DateTime::Format::Strptime|DateTime::Format::Strptime> patterns
+C<%FT%T.%N%z> or C<%F>
 
 =cut
 
 sub make_date {
     my ( $self, $date ) = @_;
     return unless $date;
-    my $pattern = '%FT%T.%N%z';
-    state $parser = DateTime::Format::Strptime->new( pattern => $pattern );
+    my $pattern = ( $date =~ m/\dt\d/ ) ? '%FT%T.%N%z' : '%F';
+
+    my $parser = DateTime::Format::Strptime->new(
+        pattern => $pattern,
+        on_error => 'croak',
+    );
     return (
         $parser->parse_datetime( $date )
-            or
             confess qq{Unable to parse date "$date" using pattern "$pattern"}
     );
 }


### PR DESCRIPTION
I came across an issue in our JIRA project at work that had a duedate:
'2017-08-01'. Turning that issue into an object made
JIRA::REST::Class::Factory::make_date() croak because it wasn't prepared for a
date without a timestamp.
This patch makes make_date() have a look at the date first to decide on the
correkt pattern to use for parsing the date.