### PR TITLE
Prevent croaking when JIRA uses a %F-type date

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+    Add support for user_object() that calls /rest/api/latest/myself
+
+    Changes to use Win32::Process on Windows for testing.
+
 0.10      2017-01-04 23:08:03-05:00 America/New_York
 
      More adventures in the quest for 100% success in smoke rigs.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+0.11      2017-05-29 08:40:13-04:00 America/New_York
+
     Add support for user_object() that calls /rest/api/latest/myself
 
     Changes to use Win32::Process on Windows for testing.

--- a/dist.ini
+++ b/dist.ini
@@ -110,6 +110,8 @@ remove = strict
 remove = utf8
 remove = warnings
 
+remove = Win32           ; I'm going to assume that any Win32 system will
+remove = Win32::Process  ; already have these, so they don't break unix builds
 
 [RunExtraTests]   ; ensure xt/ tests pass
 

--- a/lib/JIRA/REST/Class.pm
+++ b/lib/JIRA/REST/Class.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Abstract.pm
+++ b/lib/JIRA/REST/Class/Abstract.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Abstract.pm
+++ b/lib/JIRA/REST/Class/Abstract.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Factory.pm
+++ b/lib/JIRA/REST/Class/Factory.pm
@@ -63,16 +63,20 @@ sub make_object {
 
 Make it easy to get L<DateTime|DateTime> objects from the factory. Parses
 JIRA date strings, which are in a format that can be parsed by the
-L<DateTime::Format::Strptime|DateTime::Format::Strptime> pattern
-C<%FT%T.%N%z>
+L<DateTime::Format::Strptime|DateTime::Format::Strptime> patterns
+C<%FT%T.%N%z> or C<%F>
 
 =cut
 
 sub make_date {
     my ( $self, $date ) = @_;
     return unless $date;
-    my $pattern = '%FT%T.%N%z';
-    state $parser = DateTime::Format::Strptime->new( pattern => $pattern );
+    my $pattern = ( $date =~ m/\dt\d/ ) ? '%FT%T.%N%z' : '%F';
+
+    my $parser = DateTime::Format::Strptime->new(
+        pattern => $pattern,
+        on_error => 'croak',
+    );
     return (
         $parser->parse_datetime( $date )
             or

--- a/lib/JIRA/REST/Class/Factory.pm
+++ b/lib/JIRA/REST/Class/Factory.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Factory.pm
+++ b/lib/JIRA/REST/Class/Factory.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/FactoryTypes.pm
+++ b/lib/JIRA/REST/Class/FactoryTypes.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/FactoryTypes.pm
+++ b/lib/JIRA/REST/Class/FactoryTypes.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue.pm
+++ b/lib/JIRA/REST/Class/Issue.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue.pm
+++ b/lib/JIRA/REST/Class/Issue.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog/Change.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog/Change.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog/Change.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog/Change.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog/Change/Item.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog/Change/Item.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Changelog/Change/Item.pm
+++ b/lib/JIRA/REST/Class/Issue/Changelog/Change/Item.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Comment.pm
+++ b/lib/JIRA/REST/Class/Issue/Comment.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Comment.pm
+++ b/lib/JIRA/REST/Class/Issue/Comment.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/LinkType.pm
+++ b/lib/JIRA/REST/Class/Issue/LinkType.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/LinkType.pm
+++ b/lib/JIRA/REST/Class/Issue/LinkType.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Status.pm
+++ b/lib/JIRA/REST/Class/Issue/Status.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Status.pm
+++ b/lib/JIRA/REST/Class/Issue/Status.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Status/Category.pm
+++ b/lib/JIRA/REST/Class/Issue/Status/Category.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Status/Category.pm
+++ b/lib/JIRA/REST/Class/Issue/Status/Category.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/TimeTracking.pm
+++ b/lib/JIRA/REST/Class/Issue/TimeTracking.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/TimeTracking.pm
+++ b/lib/JIRA/REST/Class/Issue/TimeTracking.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Transitions.pm
+++ b/lib/JIRA/REST/Class/Issue/Transitions.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Transitions.pm
+++ b/lib/JIRA/REST/Class/Issue/Transitions.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Transitions/Transition.pm
+++ b/lib/JIRA/REST/Class/Issue/Transitions/Transition.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Transitions/Transition.pm
+++ b/lib/JIRA/REST/Class/Issue/Transitions/Transition.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Type.pm
+++ b/lib/JIRA/REST/Class/Issue/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Type.pm
+++ b/lib/JIRA/REST/Class/Issue/Type.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Worklog.pm
+++ b/lib/JIRA/REST/Class/Issue/Worklog.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Worklog.pm
+++ b/lib/JIRA/REST/Class/Issue/Worklog.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Worklog/Item.pm
+++ b/lib/JIRA/REST/Class/Issue/Worklog/Item.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Issue/Worklog/Item.pm
+++ b/lib/JIRA/REST/Class/Issue/Worklog/Item.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Iterator.pm
+++ b/lib/JIRA/REST/Class/Iterator.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Iterator.pm
+++ b/lib/JIRA/REST/Class/Iterator.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Mixins.pm
+++ b/lib/JIRA/REST/Class/Mixins.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Mixins.pm
+++ b/lib/JIRA/REST/Class/Mixins.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla
@@ -158,14 +158,6 @@ sub JIRA_REST { ## no critic (Capitalization)
     my $ua   = $rest->getUseragent;
     $ua->ssl_opts( SSL_verify_mode => 0, verify_hostname => 0 )
         if $args->{ssl_verify_none};
-
-    unless ( $args->{username} && $args->{password} ) {
-        if ( my $auth = $rest->{_headers}->{Authorization} ) {
-            my ( undef, $encoded ) = split /\s+/, $auth;
-            ( $args->{username}, $args->{password} ) =  #
-                split /:/, decode_base64 $encoded;
-        }
-    }
 
     return $jira_rest;
 }

--- a/lib/JIRA/REST/Class/Project.pm
+++ b/lib/JIRA/REST/Class/Project.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project.pm
+++ b/lib/JIRA/REST/Class/Project.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Category.pm
+++ b/lib/JIRA/REST/Class/Project/Category.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Category.pm
+++ b/lib/JIRA/REST/Class/Project/Category.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Component.pm
+++ b/lib/JIRA/REST/Class/Project/Component.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Component.pm
+++ b/lib/JIRA/REST/Class/Project/Component.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Version.pm
+++ b/lib/JIRA/REST/Class/Project/Version.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Project/Version.pm
+++ b/lib/JIRA/REST/Class/Project/Version.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Query.pm
+++ b/lib/JIRA/REST/Class/Query.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Query.pm
+++ b/lib/JIRA/REST/Class/Query.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Sprint.pm
+++ b/lib/JIRA/REST/Class/Sprint.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/Sprint.pm
+++ b/lib/JIRA/REST/Class/Sprint.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/User.pm
+++ b/lib/JIRA/REST/Class/User.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/lib/JIRA/REST/Class/User.pm
+++ b/lib/JIRA/REST/Class/User.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.010;
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 our $SOURCE = 'CPAN';
 $SOURCE = 'GitHub';  # COMMENT
 # the line above will be commented out by Dist::Zilla

--- a/t/01-testserver-communication.t
+++ b/t/01-testserver-communication.t
@@ -34,10 +34,10 @@ try {
         "client->url returns JIRA url $url");
 
     is( $client->username, $user,
-        "client->username returns JIRA username");
+        "client->username returns JIRA username when passed in via constructor");
 
     is( $client->password, $pass,
-        "client->password returns JIRA password");
+        "client->password returns JIRA password when passed in via constructor");
 
     my $pid = TestServer_pid();
 

--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -6,6 +6,7 @@ use 5.010;
 
 use Carp;
 use Data::Dumper::Concise;
+use HTTP::Server::Simple 0.51; # require the latest H-S-S
 use JSON;
 
 # load some TestServer::Plugin modules

--- a/t/lib/TestServer/Users.pm
+++ b/t/lib/TestServer/Users.pm
@@ -9,7 +9,14 @@ use JSON;
 sub import {
     my $class = __PACKAGE__;
     $class->register_dispatch(
+        '/rest/api/latest/myself' =>
+            sub { $class->myself(@_) },
     );
+}
+
+sub myself {
+    my ( $class, $server, $cgi ) = @_;
+    return $class->response($server, $class->user($server, $cgi, 'packy'));
 }
 
 sub user {


### PR DESCRIPTION
I came across an issue in our JIRA project at work that had a duedate:
'2017-08-01'. Turning that issue into an object made
JIRA::REST::Class::Factory::make_date() croak because it wasn't prepared for a
date without a timestamp.
This patch makes make_date() have a look at the date first to decide on the
correkt pattern to use for parsing the date.